### PR TITLE
feat(reader): add highlight mode with two-phase selection and mobile overflow menu

### DIFF
--- a/Nostos.Frontend/src/app/reader/audio-reader/audio-reader.component.ts
+++ b/Nostos.Frontend/src/app/reader/audio-reader/audio-reader.component.ts
@@ -237,6 +237,14 @@ export class AudioReader implements OnDestroy, IReader {
     // No-op: Audio reader does not support highlights
   }
 
+  commitHighlight(): void {
+    // No-op: Audio reader does not support highlights
+  }
+
+  discardHighlight(): void {
+    // No-op: Audio reader does not support highlights
+  }
+
   // --- Visibility Change: Save on hidden, resync on visible ---
   private handleVisibilityChange() {
     if (!this.player) return;

--- a/Nostos.Frontend/src/app/reader/epub-reader/epub-annotation-manager.ts
+++ b/Nostos.Frontend/src/app/reader/epub-reader/epub-annotation-manager.ts
@@ -16,6 +16,7 @@ export class EpubAnnotationManager {
 
   private highlightMode = false;
   private pendingHighlight: PendingEpubHighlight | null = null;
+  private pendingContents: any = null;
   private onSelectionCaptured?: (text: string) => void;
 
   constructor(
@@ -50,29 +51,19 @@ export class EpubAnnotationManager {
         fill-opacity: 0.3;
         mix-blend-mode: multiply;
       }
-      ::selection {
-        background: rgba(255, 255, 0, 0.3);
-      }
     `;
     contents.document.head.appendChild(style);
   }
 
-private handleSelection(cfiRange: string, contents: any) {
-    if (!this.highlightMode) return;
+  private handleSelection(cfiRange: string, contents: any) {
+    if (!this.highlightMode || !cfiRange) return;
 
     const range = this.rendition.getRange(cfiRange);
-    const selectedText = range ? range.toString() : '';
+    const selectedText = range ? range.toString().trim() : '';
+    if (!selectedText) return;
 
-    const selection = contents.window.getSelection();
-    selection?.removeAllRanges();
-
-    if (this.pendingHighlight) {
-      this.rendition.annotations.remove(this.pendingHighlight.cfiRange, 'highlight');
-    }
-
-    this.rendition.annotations.add('highlight', cfiRange);
     this.pendingHighlight = { cfiRange, selectedText };
-
+    this.pendingContents = contents;
     this.onSelectionCaptured?.(selectedText);
   }
 
@@ -80,6 +71,13 @@ private handleSelection(cfiRange: string, contents: any) {
     if (!this.pendingHighlight) return;
 
     const p = this.pendingHighlight;
+
+    this.rendition.annotations.add('highlight', p.cfiRange);
+
+    if (this.pendingContents) {
+      const selection = this.pendingContents.window.getSelection();
+      if (selection) selection.removeAllRanges();
+    }
 
     this.notesService
       .create(this.bookId, {
@@ -91,11 +89,13 @@ private handleSelection(cfiRange: string, contents: any) {
         next: (note) => {
           this.highlights.update((current) => [...current, p.cfiRange]);
           this.pendingHighlight = null;
+          this.pendingContents = null;
           if (this.onNoteCreated) this.onNoteCreated();
         },
         error: () => {
           this.rendition.annotations.remove(p.cfiRange, 'highlight');
           this.pendingHighlight = null;
+          this.pendingContents = null;
           this.onCommitFailed?.();
         },
       });
@@ -104,8 +104,13 @@ private handleSelection(cfiRange: string, contents: any) {
   discardHighlight() {
     if (!this.pendingHighlight) return;
 
-    this.rendition.annotations.remove(this.pendingHighlight.cfiRange, 'highlight');
+    if (this.pendingContents) {
+      const selection = this.pendingContents.window.getSelection();
+      if (selection) selection.removeAllRanges();
+    }
+
     this.pendingHighlight = null;
+    this.pendingContents = null;
   }
 
   public restoreHighlights(notes: Note[]) {

--- a/Nostos.Frontend/src/app/reader/epub-reader/epub-annotation-manager.ts
+++ b/Nostos.Frontend/src/app/reader/epub-reader/epub-annotation-manager.ts
@@ -4,46 +4,52 @@ import { signal, Injector } from '@angular/core';
 import { NotesService } from '../../core/services/notes.service';
 import { Note } from '../../core/dtos/note.dtos';
 
+interface PendingEpubHighlight {
+  cfiRange: string;
+  selectedText: string;
+}
+
 export class EpubAnnotationManager {
-  // Signal to track saved highlights (CFI strings)
   public highlights = signal<string[]>([]);
 
   private notesService: NotesService;
+
+  private highlightMode = false;
+  private pendingHighlight: PendingEpubHighlight | null = null;
+  private onSelectionCaptured?: (text: string) => void;
 
   constructor(
     private rendition: Rendition,
     private bookId: string,
     private injector: Injector,
     private onNoteCreated?: () => void,
+    private onCommitFailed?: () => void,
   ) {
     this.notesService = this.injector.get(NotesService);
   }
 
-  /**
-   * Initialize listeners for selection events.
-   * Works for both Mouse (PC) and Touch (Mobile).
-   */
+  setHighlightMode(enabled: boolean) {
+    this.highlightMode = enabled;
+  }
+
+  setOnSelectionCaptured(callback: (text: string) => void) {
+    this.onSelectionCaptured = callback;
+  }
+
   public init() {
     this.rendition.on('selected', (cfiRange: string, contents: any) => {
       this.handleSelection(cfiRange, contents);
     });
   }
 
-  /**
-   * Inject necessary CSS for highlights into the EPUB iframe.
-   * Call this inside the rendition.hooks.content.register hook.
-   */
   public injectHighlightStyles(contents: any) {
     const style = contents.document.createElement('style');
     style.innerHTML = `
-      /* Custom Highlight Style (Yellow Marker) */
       .epubjs-hl {
         fill: yellow;
         fill-opacity: 0.3;
         mix-blend-mode: multiply;
       }
-
-      /* Mobile/PC Native Selection Color (Match the highlight) */
       ::selection {
         background: rgba(255, 255, 0, 0.3);
       }
@@ -51,50 +57,57 @@ export class EpubAnnotationManager {
     contents.document.head.appendChild(style);
   }
 
-  /**
-   * Core logic when text is selected.
-   */
-  private handleSelection(cfiRange: string, contents: any) {
-    console.log('Selection detected:', cfiRange);
+private handleSelection(cfiRange: string, contents: any) {
+    if (!this.highlightMode) return;
 
-    // 1. Extract the selected text using the CFI
     const range = this.rendition.getRange(cfiRange);
     const selectedText = range ? range.toString() : '';
 
-    // 2. Visually add the highlight immediately (Optimistic UI)
-    this.rendition.annotations.add('highlight', cfiRange);
-
-    // 3. Clear the native browser selection
     const selection = contents.window.getSelection();
     selection?.removeAllRanges();
 
-    // 4. Save to Backend
+    if (this.pendingHighlight) {
+      this.rendition.annotations.remove(this.pendingHighlight.cfiRange, 'highlight');
+    }
+
+    this.rendition.annotations.add('highlight', cfiRange);
+    this.pendingHighlight = { cfiRange, selectedText };
+
+    this.onSelectionCaptured?.(selectedText);
+  }
+
+  commitHighlight() {
+    if (!this.pendingHighlight) return;
+
+    const p = this.pendingHighlight;
+
     this.notesService
       .create(this.bookId, {
-        content: '', // User can add a comment later
-        cfiRange: cfiRange,
-        selectedText: selectedText,
+        content: '',
+        cfiRange: p.cfiRange,
+        selectedText: p.selectedText,
       })
       .subscribe({
         next: (note) => {
-          console.log('Highlight saved to DB:', note.id);
-          this.highlights.update((current) => [...current, cfiRange]);
-
-          // Notify the parent component so it can refresh the sidebar
+          this.highlights.update((current) => [...current, p.cfiRange]);
+          this.pendingHighlight = null;
           if (this.onNoteCreated) this.onNoteCreated();
         },
-        error: (err) => {
-          console.error('Failed to save highlight:', err);
-          // Rollback: Remove the highlight if the save failed
-          this.rendition.annotations.remove(cfiRange, 'highlight');
+        error: () => {
+          this.rendition.annotations.remove(p.cfiRange, 'highlight');
+          this.pendingHighlight = null;
+          this.onCommitFailed?.();
         },
       });
   }
 
-  /**
-   * Restore previously saved highlights from the backend
-   * Accepts Note[] objects (which contain the cfiRange)
-   */
+  discardHighlight() {
+    if (!this.pendingHighlight) return;
+
+    this.rendition.annotations.remove(this.pendingHighlight.cfiRange, 'highlight');
+    this.pendingHighlight = null;
+  }
+
   public restoreHighlights(notes: Note[]) {
     notes.forEach((note) => {
       if (note.cfiRange) {
@@ -105,11 +118,7 @@ export class EpubAnnotationManager {
   }
 
   public removeHighlight(cfiRange: string) {
-    // 1. Tell epub.js to remove the SVG/DOM elements for this CFI
-    // The second argument 'highlight' must match the type used in .add()
     this.rendition.annotations.remove(cfiRange, 'highlight');
-
-    // 2. Update the local signal state to reflect the removal
     this.highlights.update((current) => current.filter((cfi) => cfi !== cfiRange));
   }
 }

--- a/Nostos.Frontend/src/app/reader/epub-reader/epub-reader.component.ts
+++ b/Nostos.Frontend/src/app/reader/epub-reader/epub-reader.component.ts
@@ -30,6 +30,9 @@ import { IReader, ReaderProgress, TocItem } from '../reader.interface';
 export class EpubReader implements OnInit, OnDestroy, IReader {
   bookId = input.required<string>();
   noteCreated = output<void>();
+  highlightMode = input<boolean>(false);
+  selectionCaptured = output<string>();
+  commitFailed = output<void>();
 
   private notesService = inject(NotesService);
   private booksService = inject(BooksService);
@@ -62,6 +65,13 @@ export class EpubReader implements OnInit, OnDestroy, IReader {
     effect(() => {
       if (this.bookId()) {
         this.loadBook(this.bookId());
+      }
+    });
+
+    effect(() => {
+      const mode = this.highlightMode();
+      if (this.annotationManager) {
+        this.annotationManager.setHighlightMode(mode);
       }
     });
   }
@@ -235,8 +245,16 @@ export class EpubReader implements OnInit, OnDestroy, IReader {
         this.applyTheme();
         this.applyFontSize();
 
-        this.annotationManager = new EpubAnnotationManager(this.rendition!, id, this.injector, () =>
-          this.noteCreated.emit(),
+        this.annotationManager = new EpubAnnotationManager(
+          this.rendition!,
+          id,
+          this.injector,
+          () => this.noteCreated.emit(),
+          () => this.commitFailed.emit(),
+        );
+        this.annotationManager.setHighlightMode(this.highlightMode());
+        this.annotationManager.setOnSelectionCaptured((text) =>
+          this.selectionCaptured.emit(text),
         );
         this.annotationManager.init();
 
@@ -359,6 +377,14 @@ export class EpubReader implements OnInit, OnDestroy, IReader {
 
   removeHighlight(identifier: string): void {
     this.deleteHighlight(identifier);
+  }
+
+  commitHighlight(): void {
+    this.annotationManager?.commitHighlight();
+  }
+
+  discardHighlight(): void {
+    this.annotationManager?.discardHighlight();
   }
 
   ngOnDestroy(): void {

--- a/Nostos.Frontend/src/app/reader/pdf-reader/pdf-annotation-manager.ts
+++ b/Nostos.Frontend/src/app/reader/pdf-reader/pdf-annotation-manager.ts
@@ -51,7 +51,7 @@ export class PdfAnnotationManager {
   }
 
 
-  captureHighlight(): {
+  captureHighlight(keepSelection = false): {
     pageNumber: number;
     rects: HighlightRect[];
     selectedText: string;
@@ -79,7 +79,9 @@ export class PdfAnnotationManager {
       height: r.height / pageRect.height,
     }));
 
-    selection.removeAllRanges();
+    if (!keepSelection) {
+      selection.removeAllRanges();
+    }
 
     return {
       pageNumber,

--- a/Nostos.Frontend/src/app/reader/pdf-reader/pdf-reader.component.ts
+++ b/Nostos.Frontend/src/app/reader/pdf-reader/pdf-reader.component.ts
@@ -199,7 +199,7 @@ export class PdfReader implements OnInit, OnDestroy, IReader {
   onTextSelection() {
     if (!this.highlightMode()) return;
 
-    const highlight = this.highlightService.captureHighlight();
+    const highlight = this.highlightService.captureHighlight(true);
     if (!highlight) return;
 
     if (this.pendingHighlight) {
@@ -209,14 +209,6 @@ export class PdfReader implements OnInit, OnDestroy, IReader {
     }
 
     const tempId = `temp-${Date.now()}`;
-    const newHighlight: PageHighlight = {
-      id: tempId,
-      pageNumber: highlight.pageNumber,
-      rects: highlight.rects,
-    };
-
-    this.savedHighlights.push(newHighlight);
-    this.repaintPage(highlight.pageNumber);
 
     this.pendingHighlight = {
       tempId,
@@ -268,6 +260,17 @@ export class PdfReader implements OnInit, OnDestroy, IReader {
     if (!this.pendingHighlight) return;
 
     const p = this.pendingHighlight;
+    const newHighlight: PageHighlight = {
+      id: p.tempId,
+      pageNumber: p.pageNumber,
+      rects: p.rects,
+    };
+    this.savedHighlights.push(newHighlight);
+    this.repaintPage(p.pageNumber);
+
+    const selection = window.getSelection();
+    if (selection) selection.removeAllRanges();
+
     const cfiPayload = { pageNumber: p.pageNumber, rects: p.rects };
 
     this.notesService
@@ -297,9 +300,9 @@ export class PdfReader implements OnInit, OnDestroy, IReader {
   discardHighlight() {
     if (!this.pendingHighlight) return;
 
-    const p = this.pendingHighlight;
-    this.savedHighlights = this.savedHighlights.filter((h) => h.id !== p.tempId);
-    this.repaintPage(p.pageNumber);
+    const selection = window.getSelection();
+    if (selection) selection.removeAllRanges();
+
     this.pendingHighlight = null;
   }
 

--- a/Nostos.Frontend/src/app/reader/pdf-reader/pdf-reader.component.ts
+++ b/Nostos.Frontend/src/app/reader/pdf-reader/pdf-reader.component.ts
@@ -25,6 +25,13 @@ import { NotesService } from '../../core/services/notes.service';
 import { BooksService } from '../../core/services/books.service';
 import { IReader, ReaderProgress, TocItem } from '../reader.interface';
 
+interface PendingPdfHighlight {
+  tempId: string;
+  pageNumber: number;
+  rects: { left: number; top: number; width: number; height: number }[];
+  selectedText: string;
+}
+
 @Component({
   selector: 'app-pdf-reader',
   standalone: true,
@@ -42,12 +49,17 @@ export class PdfReader implements OnInit, OnDestroy, IReader {
   bookId = input.required<string>();
   initialLocation = input<string | undefined>();
   noteCreated = output<void>();
+  highlightMode = input<boolean>(false);
+  selectionCaptured = output<string>();
+  commitFailed = output<void>();
 
   sidebarVisible = input<boolean>(false);
   sidebarVisibleChange = output<boolean>();
 
   pdfSrc = computed(() => `/api/books/${this.bookId()}/file`);
   savedHighlights: PageHighlight[] = [];
+
+  private pendingHighlight: PendingPdfHighlight | null = null;
 
   // --- IReader Implementation ---
   toc = signal<TocItem[]>([]);
@@ -185,8 +197,16 @@ export class PdfReader implements OnInit, OnDestroy, IReader {
   // --- Selection Logic ---
 
   onTextSelection() {
+    if (!this.highlightMode()) return;
+
     const highlight = this.highlightService.captureHighlight();
     if (!highlight) return;
+
+    if (this.pendingHighlight) {
+      const old = this.pendingHighlight;
+      this.savedHighlights = this.savedHighlights.filter((h) => h.id !== old.tempId);
+      this.repaintPage(old.pageNumber);
+    }
 
     const tempId = `temp-${Date.now()}`;
     const newHighlight: PageHighlight = {
@@ -198,26 +218,14 @@ export class PdfReader implements OnInit, OnDestroy, IReader {
     this.savedHighlights.push(newHighlight);
     this.repaintPage(highlight.pageNumber);
 
-    const cfiPayload = { pageNumber: highlight.pageNumber, rects: highlight.rects };
-    this.notesService
-      .create(this.bookId(), {
-        content: '',
-        selectedText: highlight.selectedText,
-        cfiRange: JSON.stringify(cfiPayload),
-      })
-      .subscribe({
-        next: (createdNote) => {
-          const index = this.savedHighlights.findIndex((h) => h.id === tempId);
-          if (index !== -1) {
-            this.savedHighlights[index].id = createdNote.id;
-          }
-          this.noteCreated.emit();
-        },
-        error: () => {
-          this.savedHighlights = this.savedHighlights.filter((h) => h.id !== tempId);
-          this.repaintPage(highlight.pageNumber);
-        },
-      });
+    this.pendingHighlight = {
+      tempId,
+      pageNumber: highlight.pageNumber,
+      rects: highlight.rects,
+      selectedText: highlight.selectedText,
+    };
+
+    this.selectionCaptured.emit(highlight.selectedText);
   }
 
   // --- Helpers ---
@@ -254,6 +262,45 @@ export class PdfReader implements OnInit, OnDestroy, IReader {
       this.savedHighlights.splice(index, 1);
       this.repaintPage(pageNumber);
     }
+  }
+
+  commitHighlight() {
+    if (!this.pendingHighlight) return;
+
+    const p = this.pendingHighlight;
+    const cfiPayload = { pageNumber: p.pageNumber, rects: p.rects };
+
+    this.notesService
+      .create(this.bookId(), {
+        content: '',
+        selectedText: p.selectedText,
+        cfiRange: JSON.stringify(cfiPayload),
+      })
+      .subscribe({
+        next: (createdNote) => {
+          const index = this.savedHighlights.findIndex((h) => h.id === p.tempId);
+          if (index !== -1) {
+            this.savedHighlights[index].id = createdNote.id;
+          }
+          this.pendingHighlight = null;
+          this.noteCreated.emit();
+        },
+        error: () => {
+          this.savedHighlights = this.savedHighlights.filter((h) => h.id !== p.tempId);
+          this.repaintPage(p.pageNumber);
+          this.pendingHighlight = null;
+          this.commitFailed.emit();
+        },
+      });
+  }
+
+  discardHighlight() {
+    if (!this.pendingHighlight) return;
+
+    const p = this.pendingHighlight;
+    this.savedHighlights = this.savedHighlights.filter((h) => h.id !== p.tempId);
+    this.repaintPage(p.pageNumber);
+    this.pendingHighlight = null;
   }
 
   private repaintPage(pageNumber: number) {

--- a/Nostos.Frontend/src/app/reader/reader-shell.component.css
+++ b/Nostos.Frontend/src/app/reader/reader-shell.component.css
@@ -141,6 +141,58 @@
   background-color: var(--bg-hover);
   color: var(--color-primary);
 }
+.toolbar-desktop-nav {
+  display: contents;
+}
+
+.overflow-toggle {
+  display: none;
+}
+
+.overflow-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: transparent;
+}
+
+.overflow-menu {
+  position: fixed;
+  bottom: var(--toolbar-height);
+  left: 0;
+  right: 0;
+  z-index: 41;
+  background: var(--bg-surface);
+  border-top: 1px solid var(--border-color);
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.1);
+  padding: 0.5rem;
+  padding-bottom: calc(0.5rem + env(safe-area-inset-bottom, 0px));
+}
+
+.overflow-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: none;
+  background: transparent;
+  color: var(--color-text-main);
+  font-size: 0.9rem;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  min-height: 48px;
+}
+
+.overflow-item:hover {
+  background-color: var(--bg-hover);
+}
+
+.overflow-item lucide-icon {
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
 .reader-toolbar {
   height: var(--toolbar-height);
   background: var(--bg-surface);
@@ -357,11 +409,23 @@
     color: inherit;
     border-color: inherit;
   }
+  .icon-btn.active,
+  .icon-btn.active:hover {
+    background-color: var(--color-primary);
+    color: #fff;
+    border-color: var(--color-primary);
+  }
   .icon-btn lucide-icon {
     top: 0;
   }
   .desktop-only {
     display: none;
+  }
+  .toolbar-desktop-nav {
+    display: none;
+  }
+  .overflow-toggle {
+    display: inline-flex;
   }
   .progress-display {
     min-width: auto;

--- a/Nostos.Frontend/src/app/reader/reader-shell.component.css
+++ b/Nostos.Frontend/src/app/reader/reader-shell.component.css
@@ -257,6 +257,56 @@
   border-radius: var(--radius-md);
 }
 
+.highlight-confirmation {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  background: var(--bg-surface);
+  border-top: 1px solid var(--border-color);
+  padding: 0;
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.1);
+}
+
+.confirmation-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  padding-bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
+  min-height: 56px;
+}
+
+.selected-text {
+  flex: 1;
+  margin: 0;
+  color: var(--color-text-main);
+  font-style: italic;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.confirmation-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.confirmation-actions .btn {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  white-space: nowrap;
+  min-height: 44px;
+}
+
 .toc-subitems {
   padding-left: 1.5rem; /* Indent children */
   border-left: 1px solid var(--border-light); /* Optional: visual guide line */
@@ -325,5 +375,13 @@
   }
   .info-tooltip {
     display: none;
+  }
+  .confirmation-content {
+    padding: 0.5rem 0.75rem;
+    padding-bottom: calc(0.5rem + env(safe-area-inset-bottom, 0px));
+    gap: 0.75rem;
+  }
+  .selected-text {
+    font-size: 0.8rem;
   }
 }

--- a/Nostos.Frontend/src/app/reader/reader-shell.component.css
+++ b/Nostos.Frontend/src/app/reader/reader-shell.component.css
@@ -183,7 +183,8 @@
   border-color: var(--border-color);
 }
 .icon-btn.active {
-  color: var(--color-primary);
+  background-color: var(--color-primary);
+  color: #fff;
   border-color: var(--color-primary);
 }
 .error,

--- a/Nostos.Frontend/src/app/reader/reader-shell.component.html
+++ b/Nostos.Frontend/src/app/reader/reader-shell.component.html
@@ -8,16 +8,34 @@
         [bookId]="book()!.id"
         [initialLocation]="book()?.lastLocation"
         [sidebarVisible]="tocOpen()"
+        [highlightMode]="highlightMode()"
         (sidebarVisibleChange)="tocOpen.set($event)"
         (noteCreated)="handleNoteCreated()"
+        (selectionCaptured)="handleSelectionCaptured($event)"
+        (commitFailed)="handleCommitFailed()"
       />
       } @case ('epub') {
-      <app-epub-reader [bookId]="book()!.id" (noteCreated)="handleNoteCreated()" />
+      <app-epub-reader [bookId]="book()!.id" [highlightMode]="highlightMode()" (noteCreated)="handleNoteCreated()" (selectionCaptured)="handleSelectionCaptured($event)" (commitFailed)="handleCommitFailed()" />
       } @case ('audio') {
       <app-audio-reader [bookId]="book()!.id" />
       } @default {
       <div class="error">Unsupported file format.</div>
       } } }
+
+      @if (pendingSelectionText() !== null) {
+      <div class="highlight-confirmation">
+        <div class="confirmation-content">
+          <p class="selected-text">"{{ pendingSelectionText()!.length > 60 ? pendingSelectionText()!.slice(0, 60) + '...' : pendingSelectionText()! }}"</p>
+          <div class="confirmation-actions">
+            <button class="btn btn-secondary" (click)="discardHighlight()">Cancel</button>
+            <button class="btn btn-primary" (click)="commitHighlight()">
+              <lucide-icon [img]="Icons.Check" [size]="16"></lucide-icon>
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+      }
     </main>
 
     <aside class="toc-panel" [class.open]="tocOpen() && fileType() !== 'pdf'">
@@ -155,6 +173,14 @@
 
     <div class="toolbar-right">
       @if (fileType() !== 'audio') {
+      <button
+        class="icon-btn"
+        [class.active]="highlightMode()"
+        (click)="toggleHighlightMode()"
+        title="Highlight mode"
+      >
+        <lucide-icon [img]="Icons.Highlighter" [size]="20"></lucide-icon>
+      </button>
       <button class="icon-btn desktop-only" (click)="zoomOut()">
         <lucide-icon [img]="Icons.ZoomOut" [size]="20"></lucide-icon>
       </button>

--- a/Nostos.Frontend/src/app/reader/reader-shell.component.html
+++ b/Nostos.Frontend/src/app/reader/reader-shell.component.html
@@ -128,14 +128,37 @@
     </aside>
   </div>
 
+  @if (overflowOpen()) {
+  <div class="overflow-backdrop" (click)="overflowOpen.set(false)"></div>
+  <div class="overflow-menu">
+    <button class="overflow-item" (click)="goBack(); overflowOpen.set(false)">
+      <lucide-icon [img]="Icons.ArrowLeft" [size]="18"></lucide-icon>
+      <span>Back to Library</span>
+    </button>
+    <button class="overflow-item" (click)="toggleToc(); overflowOpen.set(false)">
+      <lucide-icon [img]="Icons.List" [size]="18"></lucide-icon>
+      <span>Table of Contents</span>
+    </button>
+    <button class="overflow-item" (click)="toggleNotes(); overflowOpen.set(false)">
+      <lucide-icon [img]="Icons.NotebookPen" [size]="18"></lucide-icon>
+      <span>Notes & Highlights</span>
+    </button>
+  </div>
+  }
+
   <header class="reader-toolbar">
     <div class="toolbar-left">
-      <button class="icon-btn" (click)="goBack()">
-        <lucide-icon [img]="Icons.ArrowLeft" [size]="20"></lucide-icon>
+      <button class="icon-btn overflow-toggle" (click)="toggleOverflow()" title="More">
+        <lucide-icon [img]="Icons.MoreHorizontal" [size]="20"></lucide-icon>
       </button>
-      <button class="icon-btn" (click)="toggleToc()" title="Table of Contents">
-        <lucide-icon [img]="Icons.List" [size]="20"></lucide-icon>
-      </button>
+      <div class="toolbar-desktop-nav">
+        <button class="icon-btn" (click)="goBack()">
+          <lucide-icon [img]="Icons.ArrowLeft" [size]="20"></lucide-icon>
+        </button>
+        <button class="icon-btn" (click)="toggleToc()" title="Table of Contents">
+          <lucide-icon [img]="Icons.List" [size]="20"></lucide-icon>
+        </button>
+      </div>
     </div>
 
     <div class="toolbar-center">
@@ -188,7 +211,7 @@
         <lucide-icon [img]="Icons.ZoomIn" [size]="20"></lucide-icon>
       </button>
       }
-      <button class="icon-btn" (click)="toggleNotes()" [class.active]="notesOpen()">
+      <button class="icon-btn desktop-only" (click)="toggleNotes()" [class.active]="notesOpen()">
         <lucide-icon [img]="Icons.NotebookPen" [size]="20"></lucide-icon>
       </button>
     </div>

--- a/Nostos.Frontend/src/app/reader/reader-shell.component.ts
+++ b/Nostos.Frontend/src/app/reader/reader-shell.component.ts
@@ -6,6 +6,7 @@ import {
   LucideAngularModule,
   ArrowLeft,
   NotebookPen,
+  Highlighter,
   MessageSquareQuote,
   StickyNote,
   Edit2,
@@ -71,9 +72,11 @@ export class ReaderShell implements OnInit {
   // Icons
   Icons = {
     ArrowLeft,
+    Highlighter,
     NotebookPen,
     StickyNote,
     Close: X,
+    Check,
     Clock,
     List,
     ZoomIn,
@@ -90,6 +93,9 @@ export class ReaderShell implements OnInit {
   notesOpen = signal(false);
   tocOpen = signal(false);
   ready = signal(false);
+  highlightMode = signal(false);
+  pendingSelectionText = signal<string | null>(null);
+  private lastPendingText: string | null = null;
 
   dbNotes = signal<Note[]>([]);
   quickNoteContent = signal('');
@@ -190,11 +196,45 @@ export class ReaderShell implements OnInit {
       this.loadNotes(id);
       if (!this.notesOpen()) this.notesOpen.set(true);
     }
+    this.lastPendingText = null;
   }
 
   toggleNotes() {
     this.notesOpen.update((v) => !v);
     if (this.notesOpen()) this.tocOpen.set(false);
+  }
+
+  toggleHighlightMode() {
+    const newMode = !this.highlightMode();
+    if (!newMode && this.pendingSelectionText()) {
+      this.activeReader()?.discardHighlight();
+      this.pendingSelectionText.set(null);
+    }
+    this.lastPendingText = null;
+    this.highlightMode.set(newMode);
+  }
+
+  commitHighlight() {
+    this.lastPendingText = this.pendingSelectionText();
+    this.pendingSelectionText.set(null);
+    this.activeReader()?.commitHighlight();
+  }
+
+  handleCommitFailed() {
+    if (this.lastPendingText !== null) {
+      this.pendingSelectionText.set(this.lastPendingText);
+      this.lastPendingText = null;
+    }
+  }
+
+  discardHighlight() {
+    this.activeReader()?.discardHighlight();
+    this.pendingSelectionText.set(null);
+    this.lastPendingText = null;
+  }
+
+  handleSelectionCaptured(text: string) {
+    this.pendingSelectionText.set(text);
   }
 
   toggleToc() {

--- a/Nostos.Frontend/src/app/reader/reader-shell.component.ts
+++ b/Nostos.Frontend/src/app/reader/reader-shell.component.ts
@@ -15,6 +15,7 @@ import {
   Check,
   Clock,
   List,
+  MoreHorizontal,
   ZoomIn,
   ZoomOut,
   ChevronLeft,
@@ -79,6 +80,7 @@ export class ReaderShell implements OnInit {
     Check,
     Clock,
     List,
+    MoreHorizontal,
     ZoomIn,
     ZoomOut,
     Prev: ChevronLeft,
@@ -95,6 +97,7 @@ export class ReaderShell implements OnInit {
   ready = signal(false);
   highlightMode = signal(false);
   pendingSelectionText = signal<string | null>(null);
+  overflowOpen = signal(false);
   private lastPendingText: string | null = null;
 
   dbNotes = signal<Note[]>([]);
@@ -156,6 +159,11 @@ export class ReaderShell implements OnInit {
   ngOnInit() {
     this.loadConcepts();
 
+    const mql = window.matchMedia('(min-width: 769px)');
+    mql.addEventListener('change', (e) => {
+      if (e.matches) this.overflowOpen.set(false);
+    });
+
     const id = this.route.snapshot.paramMap.get('id');
     if (id) {
       this.booksService.get(id).subscribe({
@@ -212,6 +220,10 @@ export class ReaderShell implements OnInit {
     }
     this.lastPendingText = null;
     this.highlightMode.set(newMode);
+  }
+
+  toggleOverflow() {
+    this.overflowOpen.update((v) => !v);
   }
 
   commitHighlight() {

--- a/Nostos.Frontend/src/app/reader/reader.interface.ts
+++ b/Nostos.Frontend/src/app/reader/reader.interface.ts
@@ -30,6 +30,8 @@ export interface IReader {
 
   // Highlight Management
   removeHighlight(identifier: string): void;
+  commitHighlight(): void;
+  discardHighlight(): void;
 
   // Reactive State
   toc: Signal<TocItem[]>;


### PR DESCRIPTION
## Summary

Replaces the old instant-highlight-on-select flow with a toggle-based
highlight mode that decouples text selection from note creation.

### Core Feature — Highlight Mode Toggle
- **Toggle button** in the bottom toolbar (always visible on mobile)
- When **ON**: selecting text captures a pending highlight, confirmation
  bar appears with Save/Cancel. EPUB swipe navigation is disabled.
- When **OFF**: text selection does nothing (no accidental highlights)
- On Save failure, the confirmation bar re-appears for retry
- Mode stays active after saving for consecutive highlights

### Mobile Overflow Menu
- Back, TOC, and Notes collapse into a &#x22ee; popup on narrow viewports
- Highlight toggle stays one tap away at all times
- Closes on rotation to desktop width

### Bug Fixes
- EPUB/PDF text selection no longer instantly cleared &#x2014; native selection
  handles stay visible until commit, allowing endpoint adjustment
- Removed yellow ::selection tint when highlight mode is off
- Fixed iOS sticky :hover overriding the active button state
- Eliminated double-annotation cleanup race in setHighlightMode