### PR TITLE
fix: soften audio speed pill hover state

### DIFF
--- a/Nostos.Frontend/src/app/reader/audio-reader/audio-reader.component.css
+++ b/Nostos.Frontend/src/app/reader/audio-reader/audio-reader.component.css
@@ -248,19 +248,21 @@
   color: var(--color-text-main);
   line-height: 1;
   outline: none;
-  transition: border-color 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
 }
 
 .rate-pill:hover {
-  border-color: var(--color-primary);
+  border-color: var(--color-primary-dim);
 }
 
 .rate-pill:focus-visible {
-  border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px rgba(17, 17, 17, 0.08);
+  border-color: var(--border-focus);
+  box-shadow: 0 0 0 2px rgba(102, 102, 102, 0.04);
 }
 
 .rate-value {


### PR DESCRIPTION
## Summary
- restore the audio speed pill's resting border to the normal border token
- soften the hover border with the dim primary token
- keep the focus state subtler without reusing the hover border color

## Verification
- npm run build:frontend
- PM2 restart: PM2_HOME=/home/dev/.pm2 pm2 restart nostos --update-env
- Browser checked audio reader speed dropdown open/select/close behavior at /read/9acb58cb-c89f-429e-8043-8fbd43199cb6
- Browser console: no errors