### PR TITLE
fix: preserve UTC timestamps in API responses

### DIFF
--- a/Nostos.Backend/Data/NostosDbContext.cs
+++ b/Nostos.Backend/Data/NostosDbContext.cs
@@ -22,6 +22,12 @@ public class NostosDbContext(DbContextOptions<NostosDbContext> options) : DbCont
     public DbSet<NoteConceptModel> NoteConcepts => Set<NoteConceptModel>();
     public DbSet<BackupRecord> BackupRecords => Set<BackupRecord>();
 
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        configurationBuilder.Properties<DateTime>().HaveConversion<UtcDateTimeValueConverter>();
+        configurationBuilder.Properties<DateTime?>().HaveConversion<NullableUtcDateTimeValueConverter>();
+    }
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);

--- a/Nostos.Backend/Data/UtcDateTimeValueConverters.cs
+++ b/Nostos.Backend/Data/UtcDateTimeValueConverters.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Nostos.Backend.Data;
+
+public sealed class UtcDateTimeValueConverter()
+    : ValueConverter<DateTime, DateTime>(
+        value => NormalizeUtc(value),
+        value => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+    )
+{
+    private static DateTime NormalizeUtc(DateTime value) =>
+        value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+        };
+}
+
+public sealed class NullableUtcDateTimeValueConverter()
+    : ValueConverter<DateTime?, DateTime?>(
+        value => value.HasValue ? NormalizeUtc(value.Value) : null,
+        value => value.HasValue ? DateTime.SpecifyKind(value.Value, DateTimeKind.Utc) : null
+    )
+{
+    private static DateTime NormalizeUtc(DateTime value) =>
+        value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+        };
+}

--- a/Nostos.Backend/Program.cs
+++ b/Nostos.Backend/Program.cs
@@ -5,6 +5,7 @@ using Nostos.Backend.Data;
 using Nostos.Backend.Data.Interfaces;
 using Nostos.Backend.Data.Repositories;
 using Nostos.Backend.Endpoints;
+using Nostos.Backend.Serialization;
 using Nostos.Backend.Services;
 using Nostos.Backend.Workers;
 
@@ -37,6 +38,11 @@ builder.WebHost.ConfigureKestrel(options =>
 builder.Services.Configure<FormOptions>(options =>
 {
     options.MultipartBodyLengthLimit = maxUploadSizeGB;
+});
+
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.Converters.Add(new UtcDateTimeJsonConverter());
 });
 
 builder.Services.AddOpenApi();

--- a/Nostos.Backend/Serialization/UtcDateTimeJsonConverter.cs
+++ b/Nostos.Backend/Serialization/UtcDateTimeJsonConverter.cs
@@ -1,0 +1,37 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Nostos.Backend.Serialization;
+
+public sealed class UtcDateTimeJsonConverter : JsonConverter<DateTime>
+{
+    public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            throw new JsonException($"Expected string token when parsing {nameof(DateTime)}.");
+        }
+
+        var value = reader.GetString();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new JsonException($"Cannot parse an empty {nameof(DateTime)} value.");
+        }
+
+        return NormalizeUtc(DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind));
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(NormalizeUtc(value).ToString("O", CultureInfo.InvariantCulture));
+    }
+
+    private static DateTime NormalizeUtc(DateTime value) =>
+        value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+        };
+}


### PR DESCRIPTION
## Summary
- Serialize backend DateTime values with explicit UTC timezone information
- Preserve UTC DateTime kind when reading DateTime/DateTime? values from SQLite
- Treat existing SQLite timestamps with unspecified kind as UTC

Closes #17

## Verification
- dotnet build Nostos.sln
- Manual API check confirmed timestamps include trailing Z for browser-local display