### PR TITLE
fix: align audio reader current-time timestamp with total-time timestamp

### DIFF
--- a/Nostos.Frontend/src/app/reader/audio-reader/audio-reader.component.css
+++ b/Nostos.Frontend/src/app/reader/audio-reader/audio-reader.component.css
@@ -135,12 +135,11 @@
 /* Shared layout properties to guarantee zero layout shift */
 .time-label-btn,
 .time-edit-input {
-  width: 96px;
   min-height: 44px;
   font: inherit;
   font-variant-numeric: tabular-nums;
   padding: 0.5rem 0.25rem;
-  text-align: center;
+  text-align: left;
   box-sizing: border-box;
   border: none;
   border-bottom: 1px solid transparent;

--- a/Nostos.Frontend/src/app/reader/audio-reader/audio-reader.component.html
+++ b/Nostos.Frontend/src/app/reader/audio-reader/audio-reader.component.html
@@ -32,6 +32,7 @@
             #timeInput
             class="time-edit-input"
             type="text"
+            size="6"
             inputmode="text"
             [value]="timeInputValue()"
             (keydown.enter)="commitTimeEdit(timeInput.value); $event.preventDefault()"


### PR DESCRIPTION
## What

Removes the fixed `width: 96px` and `text-align: center` from the current-time timestamp button/input in the audio reader, so it sizes to content naturally — matching the right-side total-time span.

## Before
- Left timestamp: fixed 96px box with centered text
- Right timestamp: natural-width span

## After
- Both timestamps size to their content width
- Both left-align within their natural bounding box
- `justify-content: space-between` still pushes them to opposite ends
- `min-height: 44px` and padding preserved for accessibility

## Changed files
- `Nostos.Frontend/src/app/reader/audio-reader/audio-reader.component.css` — 1 insertion, 2 deletions

## Verification
- `ng build --configuration development` — clean
- `ng test` — 17 passed, 7 failed (all pre-existing `ActivatedRoute` provider failures)